### PR TITLE
ci: make validate-examples trigger reliably

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -1,7 +1,15 @@
 name: Validate examples
+
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'schema/**'
+      - 'examples/**'
+      - 'scripts/**'
+      - '.github/workflows/validate-examples.yml'
   workflow_dispatch:
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -10,5 +18,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm i ajv@^8 ajv-formats@^3
-      - run: node scripts/validate-examples.mjs
+      - run: npm ci || npm i
+      - run: node scripts/validate.mjs


### PR DESCRIPTION
Adds workflow_dispatch and explicit pull_request types to avoid 'no checks reported'.