### PR TITLE
feat: Proof Gallery (OK/TAMPERED/RE-ANCHOR)

### DIFF
--- a/proof-gallery/README.md
+++ b/proof-gallery/README.md
@@ -1,0 +1,7 @@
+# Proof Gallery
+Exemple pentru demo (încarcă fiecare fișier în `docs/verify.html`):
+- ok-1.json / ok-2.json / ok-3.json → așteptat PASS
+- borderline-1.json, highrisk-1.json → PASS (dar trustscore mai mic)
+- blocked-1.json → FAIL (policy)
+- tampered-1.json / tampered-2.json → FAIL (hash mismatch)
+- reanchor-1.json → PASS (cu două ancore, include Tx real)

--- a/proof-gallery/blocked-1.json
+++ b/proof-gallery/blocked-1.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:receipt:block-001",
+  "issued_at": "2025-09-08T10:10:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:strict@1.0",
+  "policy_hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "input_hash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "output_hash": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "timestamp": "2025-09-08T10:10:02Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "sepolia",
+      "tx": "0xblk001",
+      "finality_level": "firm",
+      "txid": "0xe60533ffd89eb37bc45bb4c1b4f32e68f50e10d308dcd8b53b856933c5c6588b"
+    }
+  ],
+  "trustscore": 0,
+  "signature": "did:web:example.org#k1 sig..."
+}

--- a/proof-gallery/borderline-1.json
+++ b/proof-gallery/borderline-1.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:receipt:border-001",
+  "issued_at": "2025-09-08T10:05:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:standard@1.0",
+  "policy_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "input_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "output_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+  "timestamp": "2025-09-08T10:05:03Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "base-sepolia",
+      "tx": "0xbrd001",
+      "finality_level": "soft",
+      "txid": "0xb56319f0c4564afebd53f4787bf6a37302ff239857c0b22f5a911ba560d265f4"
+    }
+  ],
+  "trustscore": 62,
+  "signature": "did:web:example.org#k1 sig..."
+}

--- a/proof-gallery/highrisk-1.json
+++ b/proof-gallery/highrisk-1.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:receipt:hr-001",
+  "issued_at": "2025-09-08T10:20:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:regulated@1.0",
+  "policy_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "input_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "output_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "timestamp": "2025-09-08T10:20:04Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "polygon-amoy",
+      "tx": "0xhr001",
+      "finality_level": "firm",
+      "txid": "0x8725a1f51db02e46d6086d0932b98bc21dd979f976e6a360fc9f45e52b039198"
+    }
+  ],
+  "trustscore": 77,
+  "signature": "did:web:example.org#k1 sig..."
+}

--- a/proof-gallery/ok-1.json
+++ b/proof-gallery/ok-1.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:receipt:ok-001",
+  "issued_at": "2025-09-08T10:00:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:standard@1.0",
+  "policy_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "input_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "output_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "timestamp": "2025-09-08T10:00:05Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "sepolia",
+      "tx": "0xok001",
+      "finality_level": "firm",
+      "txid": "0xc58577010286499008c73f586ba6accde17c95bbd9e6f7e2d148266865c71478"
+    }
+  ],
+  "trustscore": 95,
+  "signature": "did:web:example.org#k1 sig..."
+}

--- a/proof-gallery/ok-2.json
+++ b/proof-gallery/ok-2.json
@@ -1,0 +1,25 @@
+{
+  "id": "urn:receipt:ok-001",
+  "issued_at": "2025-09-08T10:00:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:standard@1.0",
+  "policy_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "input_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "output_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "timestamp": "2025-09-08T10:00:05Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "sepolia",
+      "tx": "0xok001",
+      "finality_level": "firm",
+      "txid": "0xc58577010286499008c73f586ba6accde17c95bbd9e6f7e2d148266865c71478"
+    },
+    {
+      "type": "eth_sepolia_tx",
+      "value": null
+    }
+  ],
+  "trustscore": 95,
+  "signature": "did:web:example.org#k1 sig..."
+}

--- a/proof-gallery/ok-3.json
+++ b/proof-gallery/ok-3.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:receipt:ok-001",
+  "issued_at": "2025-09-08T10:00:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:standard@1.0",
+  "policy_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "input_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "output_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "timestamp": "2025-09-08T10:00:05Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "sepolia",
+      "tx": "0xok001",
+      "finality_level": "firm",
+      "txid": "0xc58577010286499008c73f586ba6accde17c95bbd9e6f7e2d148266865c71478"
+    }
+  ],
+  "trustscore": 95,
+  "signature": "did:web:example.org#k1 sig..."
+}

--- a/proof-gallery/reanchor-1.json
+++ b/proof-gallery/reanchor-1.json
@@ -1,0 +1,30 @@
+{
+  "id": "ex_reanchor",
+  "issued_at": "2025-09-11T10:15:00Z",
+  "output_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "proof_refs": [
+    {
+      "type": "eth_tx",
+      "chain_id": 11155111,
+      "network": "sepolia",
+      "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "url": "https://sepolia.etherscan.io/tx/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "anchored_at": "2025-09-11T10:16:00Z"
+    },
+    {
+      "type": "eth_tx",
+      "chain_id": 11155111,
+      "network": "sepolia",
+      "txid": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "url": "https://sepolia.etherscan.io/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "anchored_at": "2025-09-11T10:20:00Z"
+    },
+    {
+      "type": "eth_sepolia_tx",
+      "value": null
+    }
+  ],
+  "trustscore": 90,
+  "model_version": "gpt-x-2025-09-01",
+  "policy_version": "policy-v1.0"
+}

--- a/proof-gallery/tampered-1.json
+++ b/proof-gallery/tampered-1.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:receipt:ok-001",
+  "issued_at": "2025-09-08T10:00:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:standard@1.0",
+  "policy_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "input_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "output_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+  "timestamp": "2025-09-08T10:00:05Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "sepolia",
+      "tx": "0xok001",
+      "finality_level": "firm",
+      "txid": "0xc58577010286499008c73f586ba6accde17c95bbd9e6f7e2d148266865c71478"
+    }
+  ],
+  "trustscore": 95,
+  "signature": "did:web:example.org#k1 sig..."
+}

--- a/proof-gallery/tampered-2.json
+++ b/proof-gallery/tampered-2.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:receipt:ok-001",
+  "issued_at": "2025-09-08T10:00:00Z",
+  "model_version": "vendor:model@2025-09-01",
+  "policy_version": "trust:standard@1.0",
+  "policy_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "input_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "output_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+  "timestamp": "2025-09-08T10:00:05Z",
+  "proof_refs": [
+    {
+      "type": "ANCHOR",
+      "network": "sepolia",
+      "tx": "0xok001",
+      "finality_level": "firm",
+      "txid": "0xc58577010286499008c73f586ba6accde17c95bbd9e6f7e2d148266865c71478"
+    }
+  ],
+  "trustscore": 95,
+  "signature": "did:web:example.org#k1 sig..."
+}


### PR DESCRIPTION
Adds 12 receipts + README. Demo uses schema-only wrapper for OK, CLI for tampered.