### PR TITLE
ci/spec sanity extend

### DIFF
--- a/.github/workflows/spec-sanity.yml
+++ b/.github/workflows/spec-sanity.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
       - run: npm i -g ajv-cli@5 ajv-formats
       - run: ajv validate -c ajv-formats -s docs/receipt.schema.json -d "examples/*.json"
       - run: ajv validate -c ajv-formats -s docs/receipt.schema.json -d "proof-gallery/*.json"
+  no-cdn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: "! grep -RniE 'jsdelivr|unpkg|cdn' docs || (echo 'CDN refs found' && exit 1)"

--- a/docs/audit.html
+++ b/docs/audit.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'">
 <title>AI Trust Receipt — Audit Pack</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <style>


### PR DESCRIPTION
- **docs: add meta CSP fallback (default-src 'self')**
- **ci: ajv sanity + block CDN refs**
